### PR TITLE
Make bindings compatible for all NLopt 2.* versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
           compiler: gnu
           version: 10
 
+        - os: macos-latest
+          build: meson
+          build-type: coverage
+          compiler: gnu
+          version: 10
+
     defaults:
       run:
         shell: ${{ matrix.shell || 'bash' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,13 @@ add_subdirectory("config")
 if(NOT TARGET "NLopt::nlopt")
   find_package("NLopt")
 endif()
+# Encode version of NLopt library as integer to allow usage in preprocessor guards
+math(
+  EXPR "NLOPT_CVERSION"
+  "${NLopt_VERSION_MAJOR} * 10000
+  +${NLopt_VERSION_MINOR} * 100
+  +${NLopt_VERSION_PATCH}"
+)
 
 set(
   lib-deps
@@ -52,6 +59,11 @@ set_target_properties(
   VERSION "${PROJECT_VERSION}"
   SOVERSION "${PROJECT_VERSION_MAJOR}"
   Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/include"
+)
+target_compile_definitions(
+  "${PROJECT_NAME}-lib"
+  PRIVATE
+  "NLOPT_VERSION=${NLOPT_CVERSION}"
 )
 target_link_libraries(
   "${PROJECT_NAME}-lib"

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ To build this project from the source code in this repository you need to have
 - a Fortran compiler supporting Fortran 2008 (GCC 5 or newer or Intel Fortran)
 - One of the supported build systems
 
-  - [meson](https://mesonbuild.com) version 0.55 or newer
+  - [meson](https://mesonbuild.com) version 0.55 or newer, with
+    a build-system backend, *i.e.* [ninja](https://ninja-build.org) version 1.7 or newer
+  - [cmake](https://cmake.org) version 3.14 or newer, with
+    a build-system backend, *i.e.* [ninja](https://ninja-build.org) version 1.10 or newer
   - [Fortran package manager (fpm)](https://github.com/fortran-lang/fpm) version 0.2.0 or newer
 
-- [nlopt](https://nlopt.readthedocs.io/en/latest/) version 2.5.0 or later
+- [nlopt](https://nlopt.readthedocs.io/en/latest/) version 2.0.0 or later
 
 
 ### Building with meson
@@ -117,6 +120,28 @@ To use ``nlopt-f`` include it as dependency in your package manifest
 [dependencies]
 nlopt-f.git = "https://github.com/grimme-lab/nlopt-f"
 ```
+
+The Fortran bindings target NLopt 2.5.0 by default.
+You can target a specific NLopt version by adding the preprocessor define ``NLOPT_VERSION`` using a compact integer representation (major * 10000 + minor * 100 + patch).
+To target NLopt 2.6.2 use
+
+```
+fpm <cmd> --profile debug --flag "-DNLOPT_VERSION=20602"
+```
+
+If NLopt is not installed in a standard location use pkg-config to find it
+
+```
+fpm <cmd> --profile debug --flag "$(pkg-config nlopt --cflags --libs-only-L)"
+```
+
+You can check your installed NLopt version using
+
+```
+pkg-config nlopt --modversion
+```
+
+Which will print the version number.
 
 
 ## Usage

--- a/config/meson.build
+++ b/config/meson.build
@@ -36,3 +36,17 @@ elif fc_id == 'pgi' or fc_id == 'nvidia_hpc'
 endif
 
 lib_deps += dependency('nlopt', version: '>=2.0')
+if get_option('nlopt_version') == 'auto'
+  nlopt_varr = lib_deps.get(-1).version().split('.')
+else
+  if get_option('nlopt_version').version_compare('>='+lib_deps.get(-1).version())
+    error('Requested NLopt version is newer than available NLopt library')
+  endif
+  nlopt_varr = get_option('nlopt_version').split('.')
+endif
+nlopt_version = nlopt_varr.get(0, '0').to_int() * 10000 \
+    + nlopt_varr.get(1, '0').to_int() * 100 \
+    + nlopt_varr.get(2, '0').to_int()
+lib_deps += declare_dependency(
+  compile_args: '-DNLOPT_VERSION='+nlopt_version.to_string()
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,30 @@
+# This file is part of nlopt-f.
+# SPDX-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of Apache License, Version 2.0 or MIT license
+# at your option; you may not use this file except in compliance with
+# the License.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(
+  'nlopt_version',
+  type: 'combo',
+  value: 'auto',
+  choices: [
+    'auto',
+    '2.7.0',
+    '2.6.0', '2.6.1', '2.6.2',
+    '2.5.0',
+    '2.4.0', '2.4.1', '2.4.2',
+    '2.3.0',
+    '2.2.0', '2.2.1', '2.2.2', '2.2.3',
+    '2.1.0', '2.1.1', '2.1.2',
+    '2.0.0', '2.0.1', '2.0.2',
+  ],
+  description: 'NLopt version to target'
+)

--- a/src/nlopt_enum.F90
+++ b/src/nlopt_enum.F90
@@ -136,7 +136,9 @@ module nlopt_enum
       character(1, c_char), intent(in) :: name(*)
       integer(nlopt_algorithm) :: algorithm
     end function nlopt_algorithm_from_string
+#endif
 
+#if NLOPT_VERSION >= 20701
     ! extern const char *
     ! nlopt_result_to_string(nlopt_result stat);
     pure function nlopt_result_to_string(stat) result(name) bind(c)
@@ -179,7 +181,7 @@ contains
     integer(nlopt_result), intent(in) :: stat
     character(len=:, kind=c_char), allocatable :: name
 
-#if NLOPT_VERSION >= 20602
+#if NLOPT_VERSION >= 20701
     name = arr_to_str(from_c_char(nlopt_result_to_string(stat)))
 #else
     select case(stat)
@@ -202,7 +204,7 @@ contains
     character(len=*), intent(in) :: name
     integer(nlopt_result) :: stat
 
-#if NLOPT_VERSION >= 20602
+#if NLOPT_VERSION >= 20701
     stat = nlopt_result_from_string(as_c_char(name))
 #else
     select case(name)

--- a/src/nlopt_interface.F90
+++ b/src/nlopt_interface.F90
@@ -126,6 +126,7 @@ module nlopt_interface
       integer(nlopt_result) :: stat
     end function nlopt_set_max_objective
 
+#if NLOPT_VERSION >= 20300
     ! extern nlopt_result
     ! nlopt_set_precond_min_objective(nlopt_opt opt, nlopt_func f, nlopt_precond pre, void *f_data);
     function nlopt_set_precond_min_objective(opt, f, pre, f_data) result(stat) bind(c)
@@ -148,6 +149,7 @@ module nlopt_interface
       type(c_ptr), value :: f_data
       integer(nlopt_result) :: stat
     end function nlopt_set_precond_max_objective
+#endif
 
     ! extern nlopt_algorithm
     ! nlopt_get_algorithm(const nlopt_opt opt);
@@ -166,6 +168,7 @@ module nlopt_interface
       integer(c_int) :: n
     end function nlopt_get_dimension
 
+#if NLOPT_VERSION >= 20500
     ! extern const char *
     ! nlopt_get_errmsg(nlopt_opt opt);
     function nlopt_get_errmsg(opt) result(errmsg) bind(c)
@@ -174,6 +177,7 @@ module nlopt_interface
       type(c_ptr), value :: opt
       type(c_ptr) :: errmsg
     end function nlopt_get_errmsg
+#endif
 
 #if NLOPT_VERSION >= 20700
     ! /* generic algorithm parameters: */
@@ -323,6 +327,7 @@ module nlopt_interface
       real(c_double), value :: tol
       integer(nlopt_result) :: stat
     end function nlopt_add_inequality_constraint
+#if NLOPT_VERSION >= 20300
     ! extern nlopt_result
     ! nlopt_add_precond_inequality_constraint(nlopt_opt opt, nlopt_func fc, nlopt_precond pre, void *fc_data, double tol);
     function nlopt_add_precond_inequality_constraint(opt, fc, pre, fc_data, tol) &
@@ -336,6 +341,8 @@ module nlopt_interface
       real(c_double), value :: tol
       integer(nlopt_result) :: stat
     end function nlopt_add_precond_inequality_constraint
+#endif
+#if NLOPT_VERSION >= 20100
     ! extern nlopt_result
     ! nlopt_add_inequality_mconstraint(nlopt_opt opt, unsigned m, nlopt_mfunc fc, void *fc_data, const double *tol);
     function nlopt_add_inequality_mconstraint(opt, m, fc, fc_data, tol) &
@@ -349,6 +356,7 @@ module nlopt_interface
       real(c_double), intent(in) :: tol(*)
       integer(nlopt_result) :: stat
     end function nlopt_add_inequality_mconstraint
+#endif
 
     ! extern nlopt_result
     ! nlopt_remove_equality_constraints(nlopt_opt opt);
@@ -369,6 +377,7 @@ module nlopt_interface
       real(c_double), value :: tol
       integer(nlopt_result) :: stat
     end function nlopt_add_equality_constraint
+#if NLOPT_VERSION >= 20300
     ! extern nlopt_result
     ! nlopt_add_precond_equality_constraint(nlopt_opt opt, nlopt_func h, nlopt_precond pre, void *h_data, double tol);
     function nlopt_add_precond_equality_constraint(opt, h, pre, h_data, tol) &
@@ -382,6 +391,8 @@ module nlopt_interface
       real(c_double), value :: tol
       integer(nlopt_result) :: stat
     end function nlopt_add_precond_equality_constraint
+#endif
+#if NLOPT_VERSION > 20100
     ! extern nlopt_result
     ! nlopt_add_equality_mconstraint(nlopt_opt opt, unsigned m, nlopt_mfunc h, void *h_data, const double *tol);
     function nlopt_add_equality_mconstraint(opt, m, h, h_data, tol) result(stat) bind(c)
@@ -394,6 +405,7 @@ module nlopt_interface
       real(c_double), intent(in) :: tol(*)
       integer(nlopt_result) :: stat
     end function nlopt_add_equality_mconstraint
+#endif
 
     ! /* stopping criteria: */
 
@@ -541,6 +553,7 @@ module nlopt_interface
       integer(c_int) :: maxeval
     end function nlopt_get_maxeval
 
+#if NLOPT_VERSION >= 20500
     ! extern int
     ! nlopt_get_numevals(const nlopt_opt opt);
     function nlopt_get_numevals(opt) result(numevals) bind(c)
@@ -549,6 +562,7 @@ module nlopt_interface
       type(c_ptr), value :: opt
       integer(c_int) :: numevals
     end function nlopt_get_numevals
+#endif
 
     ! extern nlopt_result
     ! nlopt_set_maxtime(nlopt_opt opt, double maxtime);
@@ -624,6 +638,7 @@ module nlopt_interface
       integer(c_int) :: pop
     end function nlopt_get_population
 
+#if NLOPT_VERSION >= 20202
     ! extern nlopt_result
     ! nlopt_set_vector_storage(nlopt_opt opt, unsigned dim);
     function nlopt_set_vector_storage(opt, dim) result(stat) bind(c)
@@ -641,6 +656,7 @@ module nlopt_interface
       type(c_ptr), value :: opt
       integer(c_int) :: dim
     end function nlopt_get_vector_storage
+#endif
 
     ! extern nlopt_result
     ! nlopt_set_default_initial_step(nlopt_opt opt, const double *x);
@@ -775,6 +791,122 @@ contains
     integer(nlopt_result) :: stat
     stat = NLOPT_FAILURE
   end function nlopt_set_upper_bound
+#endif
+
+
+#if NLOPT_VERSION < 20500
+  ! extern const char *
+  ! nlopt_get_errmsg(nlopt_opt opt);
+  function nlopt_get_errmsg(opt) result(errmsg)
+    type(c_ptr), value :: opt
+    type(c_ptr) :: errmsg
+    errmsg = c_null_ptr
+  end function nlopt_get_errmsg
+#endif
+
+#if NLOPT_VERSION < 20500
+  ! extern int
+  ! nlopt_get_numevals(const nlopt_opt opt);
+  function nlopt_get_numevals(opt) result(numevals)
+    type(c_ptr), value :: opt
+    integer(c_int) :: numevals
+    numevals = -1_c_int
+  end function nlopt_get_numevals
+#endif
+
+#if NLOPT_VERSION < 20300
+  ! extern nlopt_result
+  ! nlopt_set_precond_min_objective(nlopt_opt opt, nlopt_func f, nlopt_precond pre, void *f_data);
+  function nlopt_set_precond_min_objective(opt, f, pre, f_data) result(stat)
+    type(c_ptr), value :: opt
+    type(c_ptr), value :: f
+    type(c_ptr), value :: pre
+    type(c_ptr), value :: f_data
+    integer(nlopt_result) :: stat
+    stat = NLOPT_FAILURE
+  end function nlopt_set_precond_min_objective
+
+  ! extern nlopt_result
+  ! nlopt_set_precond_max_objective(nlopt_opt opt, nlopt_func f, nlopt_precond pre, void *f_data);
+  function nlopt_set_precond_max_objective(opt, f, pre, f_data) result(stat)
+    type(c_ptr), value :: opt
+    type(c_funptr), value :: f
+    type(c_funptr), value :: pre
+    type(c_ptr), value :: f_data
+    integer(nlopt_result) :: stat
+    stat = NLOPT_FAILURE
+  end function nlopt_set_precond_max_objective
+
+  ! extern nlopt_result
+  ! nlopt_add_precond_inequality_constraint(nlopt_opt opt, nlopt_func fc, nlopt_precond pre, void *fc_data, double tol);
+  function nlopt_add_precond_inequality_constraint(opt, fc, pre, fc_data, tol) &
+      & result(stat)
+    type(c_ptr), value :: opt
+    type(c_funptr), value :: fc
+    type(c_funptr), value :: pre
+    type(c_ptr), value :: fc_data
+    real(c_double), value :: tol
+    integer(nlopt_result) :: stat
+    stat = NLOPT_FAILURE
+  end function nlopt_add_precond_inequality_constraint
+
+  ! extern nlopt_result
+  ! nlopt_add_precond_equality_constraint(nlopt_opt opt, nlopt_func h, nlopt_precond pre, void *h_data, double tol);
+  function nlopt_add_precond_equality_constraint(opt, h, pre, h_data, tol) &
+      & result(stat)
+    type(c_ptr), value :: opt
+    type(c_funptr), value :: h
+    type(c_funptr), value :: pre
+    type(c_ptr), value :: h_data
+    real(c_double), value :: tol
+    integer(nlopt_result) :: stat
+    stat = NLOPT_FAILURE
+  end function nlopt_add_precond_equality_constraint
+#endif
+
+#if NLOPT_VERSION < 20202
+  ! extern nlopt_result
+  ! nlopt_set_vector_storage(nlopt_opt opt, unsigned dim);
+  function nlopt_set_vector_storage(opt, dim) result(stat) bind(c)
+    type(c_ptr), value :: opt
+    integer(c_int), value :: dim
+    integer(nlopt_result) :: stat
+    stat = NLOPT_FAILURE
+  end function nlopt_set_vector_storage
+  ! extern unsigned
+  ! nlopt_get_vector_storage(const nlopt_opt opt);
+  function nlopt_get_vector_storage(opt) result(dim) bind(c)
+    type(c_ptr), value :: opt
+    integer(c_int) :: dim
+    dim = 0_c_int
+  end function nlopt_get_vector_storage
+#endif
+
+#if NLOPT_VERSION < 20100
+  ! extern nlopt_result
+  ! nlopt_add_inequality_mconstraint(nlopt_opt opt, unsigned m, nlopt_mfunc fc, void *fc_data, const double *tol);
+  function nlopt_add_inequality_mconstraint(opt, m, fc, fc_data, tol) &
+      & result(stat)
+    type(c_ptr), value :: opt
+    integer(c_int), value :: m
+    type(c_funptr), value :: fc
+    type(c_ptr), value :: fc_data
+    real(c_double), intent(in) :: tol(*)
+    integer(nlopt_result) :: stat
+    stat = NLOPT_FAILURE
+  end function nlopt_add_inequality_mconstraint
+
+  ! extern nlopt_result
+  ! nlopt_add_equality_mconstraint(nlopt_opt opt, unsigned m, nlopt_mfunc h, void *h_data, const double *tol);
+  function nlopt_add_equality_mconstraint(opt, m, h, h_data, tol) result(stat)
+    type(c_ptr), value :: opt
+    integer(c_int), value :: m
+    type(c_funptr), value :: h
+    type(c_ptr), value :: h_data
+    real(c_double), intent(in) :: tol(*)
+    integer(nlopt_result) :: stat
+    stat = NLOPT_FAILURE
+  end function nlopt_add_equality_mconstraint
 #endif
 
 end module nlopt_interface

--- a/src/nlopt_interface.F90
+++ b/src/nlopt_interface.F90
@@ -867,7 +867,7 @@ contains
 #if NLOPT_VERSION < 20202
   ! extern nlopt_result
   ! nlopt_set_vector_storage(nlopt_opt opt, unsigned dim);
-  function nlopt_set_vector_storage(opt, dim) result(stat) bind(c)
+  function nlopt_set_vector_storage(opt, dim) result(stat)
     type(c_ptr), value :: opt
     integer(c_int), value :: dim
     integer(nlopt_result) :: stat
@@ -875,7 +875,7 @@ contains
   end function nlopt_set_vector_storage
   ! extern unsigned
   ! nlopt_get_vector_storage(const nlopt_opt opt);
-  function nlopt_get_vector_storage(opt) result(dim) bind(c)
+  function nlopt_get_vector_storage(opt) result(dim)
     type(c_ptr), value :: opt
     integer(c_int) :: dim
     dim = 0_c_int


### PR DESCRIPTION
- create stubs to support all NLopt 2.* versions and allow downgrading
- allow selection of targeted NLopt version in meson
- describe how to find NLopt library with fpm
- describe how to change target version of NLopt for fpm