### PR TITLE
Ensure module output directory is generated in configure step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ target_include_directories(
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${module-dir}>
 )
+if(NOT EXISTS "${PROJECT_BINARY_DIR}/include")
+  make_directory("${PROJECT_BINARY_DIR}/include")
+endif()
 
 # Export targets for other projects
 add_library("${PROJECT_NAME}" INTERFACE)


### PR DESCRIPTION
Required if nlopt-f is used as CMake subproject