### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,24 +41,6 @@ jobs:
           compiler: gnu
           version: 10
 
-        - os: macos-latest
-          build: meson
-          build-type: coverage
-          compiler: gnu
-          version: 10
-
-        - os: macos-latest
-          build: meson
-          build-type: debug
-          compiler: gnu
-          version: 5
-
-        - os: macos-latest
-          build: cmake
-          build-type: debug
-          compiler: gnu
-          version: 6
-
         - os: ubuntu-latest
           build: meson
           build-type: debug


### PR DESCRIPTION
Dropping broken versions of GCC on MacOS.

- GCC 5 is not installable anymore on MacOS

      brew install gcc@5
      gcc@5: This formula either does not compile or function as expected on macOS
      versions newer than High Sierra due to an upstream incompatibility.
      Error: gcc@5: An unsatisfied requirement failed this build.

- gcov on MacOS is currently shaky with meson

       Traceback (most recent call last):
        File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/bin/gcovr", line 8, in <module>
          sys.exit(main())
        File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/gcovr/__main__.py", line 280, in main
          error_occurred = print_reports(covdata, options, logger)
        File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/gcovr/__main__.py", line 432, in print_reports
          if generator(covdata, output.abspath, options):
        File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/gcovr/writer/html.py", line 397, in print_html_report
          max_line_from_cdata = max(cdata.lines.keys())
      ValueError: max() arg is an empty sequence
      Traceback (most recent call last):

- GCC 6 is broken on MacOS

      /usr/local/bin/gcc   -isysroot /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -mmacosx-version-min=11.6 -o CMakeFiles/cmTC_09a2b.dir/testCCompiler.c.o -c /Users/runner/work/nlopt-f/nlopt-f/_build/CMakeFiles/CMakeTmp/testCCompiler.c
      <built-in>: error: unknown value '11.6' of -mmacosx-version-min