### PR TITLE
Fix intent in get_initial_step

### DIFF
--- a/src/nlopt_wrap.f90
+++ b/src/nlopt_wrap.f90
@@ -890,7 +890,7 @@ contains
   end subroutine set_initial_step1
 
   subroutine get_initial_step(self, x, dx, stat)
-    class(nlopt_opt), intent(inout) :: self
+    class(nlopt_opt), intent(in) :: self
     real(c_double), intent(in) :: x(*)
     real(c_double), intent(in) :: dx(*)
     integer(ik), intent(out), optional :: stat


### PR DESCRIPTION
The `opt` object has `const` in the C interface: https://github.com/stevengj/nlopt/blob/ad8ba827fc2bafb103e01736f261a1faa7ea875e/src/api/nlopt.h#L292